### PR TITLE
chore: skip ci for dependabot automerges

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,4 +218,5 @@ workflows:
               only:
                 - main
     jobs:
-      - release-management/dependabot-automerge
+      - release-management/dependabot-automerge:
+          skip-ci: true


### PR DESCRIPTION
Skip release builds when merging PRs from `dependabot-automerge`

[skip-validate-pr]