### PR TITLE
feat: verify promote for stable-rc channel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,14 @@ jobs:
       - run: yarn install
       - run: yarn promote:verify
 
+  promote-verify-rc:
+    docker:
+      - image: node:latest
+    steps:
+      - checkout
+      - run: yarn install
+      - run: yarn promote:verify-rc
+
   close-CTC:
     docker:
       - image: node:latest
@@ -226,7 +234,7 @@ workflows:
           requires:
             - release-management/release-package
             - pack-and-upload-tarballs
-      - promote-verify:
+      - promote-verify-rc:
           requires:
             - pack-and-upload-tarballs
             - pack-and-upload-macos-installer
@@ -234,7 +242,7 @@ workflows:
       - close-CTC:
           context: CLI_CTC
           requires:
-            - promote-verify
+            - promote-verify-rc
   test-pack-and-include:
     triggers:
       - schedule:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/cli",
   "description": "The Salesforce CLI",
-  "version": "1.4.0",
+  "version": "1.3.1",
   "author": "Salesforce",
   "bin": {
     "sf": "./bin/run"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/cli",
   "description": "The Salesforce CLI",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "author": "Salesforce",
   "bin": {
     "sf": "./bin/run"
@@ -123,6 +123,7 @@
     "pretarball": "./bin/dev cli:tarballs:prepare --types",
     "promote-dist-tags": "./scripts/promote-dist-tags",
     "promote:verify": "./bin/dev cli:versions:inspect --channels stable --locations archive --cli sf",
+    "promote:verify-rc": "./bin/dev cli:versions:inspect --channels stable-rc --locations archive --cli sf",
     "test:smoke-unix": "./tmp/sf/bin/sf --version && ./tmp/sf/bin/sf help && ./tmp/sf/bin/sf plugins --core",
     "test:deprecation-policy": "./bin/dev snapshot:compare",
     "test": "echo disable # sf-test",
@@ -145,7 +146,7 @@
     "@oclif/test": "^1",
     "@salesforce/dev-config": "^2.1.2",
     "@salesforce/dev-scripts": "^0.9.18",
-    "@salesforce/plugin-release-management": "^2.6.0",
+    "@salesforce/plugin-release-management": "^2.6.1",
     "@salesforce/prettier-config": "^0.0.2",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1283,10 +1283,10 @@
     open "8.2.1"
     tslib "^2"
 
-"@salesforce/plugin-release-management@^2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/plugin-release-management/-/plugin-release-management-2.6.0.tgz#83f35803ede8e49ce21face8b338b4346883158a"
-  integrity sha512-gv8T1NNnlaRQOm6S7CBADGdpY4Tg8N67z/zSVb/8NVNDnudfQOI8C4WjAEM1a77KmBxcBgOuIbnVO7AC1yb5Ww==
+"@salesforce/plugin-release-management@^2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/plugin-release-management/-/plugin-release-management-2.6.1.tgz#f4fd540a8e01648dfb8c362e238c41d39220295d"
+  integrity sha512-HmIcW7T4STqr9pAYpIv9vBEpR4CmbEp/TGweJG5KT5wgeJSe+IGO4Jc4eEOm+lNdxXsuUkKvIvU4lzNPGepAKQ==
   dependencies:
     "@oclif/config" "^1"
     "@octokit/core" "^3.4.0"


### PR DESCRIPTION
This now verifies that the `stable-rc` promotion happened correctly after a release instead of `stable` which doesn't happen on a normal release.