### PR TITLE
chore: update circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,6 +213,9 @@ workflows:
           filters:
             branches:
               only: main
+      - build-latest-rc:
+          requires:
+            - release-management/release-package
       - pack-and-upload-tarballs:
           filters:
             branches:
@@ -295,14 +298,3 @@ workflows:
           requires:
             - npm-promotions
             - promote-channels
-  build-latest-rc:
-    triggers:
-      - schedule:
-          # Wednesday mornings at 10:30am mountain
-          cron: '30 16 * * 3'
-          filters:
-            branches:
-              only:
-                - main
-    jobs:
-      - build-latest-rc


### PR DESCRIPTION
### What does this PR do?

Updates the circle config to generate the latest-rc PR/branch directly after releasing a new version. The resulting branch will be the "release" branch for the coming week until it's merged into main

### Acceptance Criteria
NA

### Testing Notes
NA

### Checklist
- [x] This change has been approved by the CLI Review Board or approval isn't required. Anything that adds/changes/deletes commands, flags, output, or json output has to be reviewed.
- [x] Does this follow the [deprecation policy](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_cli_deprecation.htm)?

### What issues does this PR fix or reference?
[skip-validate-pr]