### PR TITLE
chore: bump macos and node images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
 
   pack-and-upload-tarballs: &pack-and-upload-tarballs
     docker:
-      - image: node:14.17.1
+      - image: node:lts
     resource_class: xlarge
     steps:
       - checkout
@@ -79,7 +79,7 @@ jobs:
 
   pack-and-upload-macos-installer:
     macos:
-      xcode: 12.5.1
+      xcode: 13.2.1
     steps:
       - checkout
       - run: git fetch origin && git pull

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/cli",
   "description": "The Salesforce CLI",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "author": "Salesforce",
   "bin": {
     "sf": "./bin/run"


### PR DESCRIPTION
### What does this PR do?
Bumps the node and macos images used for packing the macos and windows installers in order to be consistent with sfdx.

### What issues does this PR fix or reference?
[skip-validate-pr]
