### PR TITLE
chore: set max listeners

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -1,5 +1,13 @@
 #!/usr/bin/env node
 
+// Since the CLI is a single process, we can have a larger amount of max listeners since
+// the process gets shut down. Don't set it to 0 (no limit) since we should still be aware
+// of rouge event listeners
+process.setMaxListeners(parseInt(process.env.SF_MAX_EVENT_LISTENERS, 10) || 1000);
+
+// Don't let other plugins override the CLI specified max listener count
+process.setMaxListeners = () => {};
+
 require('@oclif/core').run()
 .then(require('@oclif/core/flush'))
 .catch(require('@oclif/core/handle'))


### PR DESCRIPTION
### What does this PR do?

Suppresses `MaxListenersExceededWarning` in the same way that [sfdx does](https://github.com/salesforcecli/sfdx-cli/blob/main/bin/run#L6-L12)

### Testing Notes
`npm install -g @salesforce/cli@dev`

### What issues does this PR fix or reference?
@W-10514668@