### PR TITLE
Automatically highlight command names in help

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "tslib": "^2.3.1"
   },
   "resolutions": {
-    "@oclif/core": "^1.6.4",
+    "@oclif/core": "^1.7.0",
     "@salesforce/sf-plugins-core": "^1.11.0",
     "@salesforce/templates": "^54.3.0"
   },

--- a/src/help/sfHelp.ts
+++ b/src/help/sfHelp.ts
@@ -19,7 +19,7 @@ const FORMATTERS: Record<string, Formatter> = {
     format: chalk.italic,
   },
   bold: {
-    symbol: '*',
+    symbol: '**',
     format: chalk.bold,
   },
   code: {
@@ -47,10 +47,11 @@ export default class SfHelp extends Help {
   protected log(...args: string[]): void {
     const formatted = args.map((a) => {
       for (const formatter of Object.values(FORMATTERS)) {
-        const regex = new RegExp(`\\${formatter.symbol}(.*?)\\${formatter.symbol}`, 'g');
+        const symbol = `\\${formatter.symbol.split('').join('\\')}`;
+        const regex = new RegExp(`${symbol}(.*?)${symbol}`, 'g');
         const matches = a.match(regex) ?? [];
         for (const match of matches) {
-          a = a.replace(match, formatter.format(match.replace(new RegExp(`\\${formatter.symbol}`, 'g'), '')));
+          a = a.replace(match, formatter.format(match.replace(new RegExp(`${symbol}`, 'g'), '')));
         }
       }
 

--- a/src/help/sfHelp.ts
+++ b/src/help/sfHelp.ts
@@ -5,7 +5,28 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { CommandHelp, Help, Interfaces } from '@oclif/core';
+import * as chalk from 'chalk';
 import { SfCommandHelp } from './sfCommandHelp';
+
+type Formatter = {
+  symbol: string;
+  format: chalk.Chalk;
+};
+
+const FORMATTERS: Record<string, Formatter> = {
+  italics: {
+    symbol: '_',
+    format: chalk.italic,
+  },
+  bold: {
+    symbol: '*',
+    format: chalk.bold,
+  },
+  code: {
+    symbol: '`',
+    format: chalk.dim,
+  },
+};
 
 export default class SfHelp extends Help {
   protected CommandHelpClass: typeof CommandHelp = SfCommandHelp;
@@ -21,5 +42,20 @@ export default class SfHelp extends Help {
     this.commandHelpClass = super.getCommandHelpClass(command) as SfCommandHelp;
     this.commandHelpClass.showShortHelp = this.showShortHelp;
     return this.commandHelpClass;
+  }
+
+  protected log(...args: string[]): void {
+    const formatted = args.map((a) => {
+      for (const formatter of Object.values(FORMATTERS)) {
+        const regex = new RegExp(`\\${formatter.symbol}(.*?)\\${formatter.symbol}`, 'g');
+        const matches = a.match(regex) ?? [];
+        for (const match of matches) {
+          a = a.replace(match, formatter.format(match.replace(new RegExp(`\\${formatter.symbol}`, 'g'), '')));
+        }
+      }
+
+      return a;
+    });
+    super.log(...formatted);
   }
 }


### PR DESCRIPTION
### What does this PR do?

Automatically dim command names in help output

![Screen Shot 2022-04-13 at 1 55 44 PM](https://user-images.githubusercontent.com/10244328/163259833-c585ce42-4a36-4e2f-a6e2-21b42dc8af14.png)

### What issues does this PR fix or reference?
[skip-validate-pr]