### PR TITLE
Add schemas to yarn resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
   },
   "resolutions": {
     "@oclif/core": "^1.7.0",
+    "@salesforce/schemas": "1.1.0",
     "@salesforce/sf-plugins-core": "^1.11.0",
     "@salesforce/templates": "^54.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1435,9 +1435,9 @@
   resolved "https://registry.npmjs.org/@salesforce/prettier-config/-/prettier-config-0.0.2.tgz#ded39bf7cb75238edc9db6dd093649111350f8bc"
   integrity sha512-KExM355BLbxCW6siGBV7oUOotXvvVp0tAWERgzUkM2FcMb9fWrjwXDrIHc8V0UdDlA3UXtFltDWgN+Yqi+BA/g==
 
-"@salesforce/schemas@^1.0.1", "@salesforce/schemas@^1.1.0":
+"@salesforce/schemas@1.1.0", "@salesforce/schemas@^1.0.1", "@salesforce/schemas@^1.1.0":
   version "1.1.0"
-  resolved "https://registry.npmjs.org/@salesforce/schemas/-/schemas-1.1.0.tgz#bbf94a11ee036f2b0ec6ba82306cd9565a6ba26b"
+  resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.1.0.tgz#bbf94a11ee036f2b0ec6ba82306cd9565a6ba26b"
   integrity sha512-6D7DvE6nFxpLyyTnrOIbbAeCJw2r/EpinFAcMh6gU0gA/CGfSbwV/8uR3uHLYL2zCyCZLH8jJ4dZ3BzCMqc+Eg==
 
 "@salesforce/sf-plugins-core@^1.11.0", "@salesforce/sf-plugins-core@^1.12.0", "@salesforce/sf-plugins-core@^1.12.1", "@salesforce/sf-plugins-core@^1.2.1", "@salesforce/sf-plugins-core@^1.7.2", "@salesforce/sf-plugins-core@^1.9.0":


### PR DESCRIPTION
### What does this PR do?
Adds `@salesforce/schemas` to yarn resolutions so that we always get the newest version

These resolutions get bumped automatically in [plugin-release-management](https://github.com/salesforcecli/plugin-release-management/blob/main/src/commands/cli/latestrc/build.ts#L68)

### Acceptance Criteria
All builds pass

### Testing Notes
Should not need testing

### Checklist
- [NA] This change has been approved by the CLI Review Board or approval isn't required. Anything that adds/changes/deletes commands, flags, output, or json output has to be reviewed.
- [NA] Does this follow the [deprecation policy](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_cli_deprecation.htm)?

### What issues does this PR fix or reference?
[W-11048751](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-11048751)
