### PR TITLE
fix(deps): update plugin-functions to 1.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@sf/config": "npm:@salesforce/plugin-config@2.3.2",
     "@sf/deploy-retrieve": "npm:@salesforce/plugin-deploy-retrieve@1.4.3",
     "@sf/env": "npm:@salesforce/plugin-env@1.3.2",
-    "@sf/functions": "npm:@salesforce/plugin-functions@1.7.1",
+    "@sf/functions": "npm:@salesforce/plugin-functions@1.11.1",
     "@sf/gen": "npm:@salesforce/plugin-generate@1.0.14",
     "@sf/info": "npm:@salesforce/plugin-info@2.0.1",
     "@sf/login": "npm:@salesforce/plugin-login@1.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -440,15 +440,33 @@
     ajv "^6.12.2"
     toml "^3.0.0"
 
-"@heroku/functions-core@0.2.6":
-  version "0.2.6"
-  resolved "https://registry.npmjs.org/@heroku/functions-core/-/functions-core-0.2.6.tgz#48294dfd077cf99d8b247b38d4309b37c24b3dd3"
-  integrity sha512-9BoCs5ruOXBvneqQVRfTCXTlxnBo9coAOKtXUS5KO/sJfu3AUr94sDyNCPSOr3dZEb44s2IsdnSe2JI+1gjSwg==
+"@heroku/project-descriptor@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.npmjs.org/@heroku/project-descriptor/-/project-descriptor-0.0.5.tgz#1a305bee7f4d9722818cd5fee2919d7d83953ddb"
+  integrity sha512-E5+MustRcw29xLeHJ1XZubMJDMJOrN1ge20/2/0/ZAwYV2ncD10wcmOLU8G92WY4ZLzX3T1t6/aOtDbQU61zXA==
+  dependencies:
+    ajv "^8.0.0"
+    ajv-formats "^2.0.2"
+    toml "^3.0.0"
+
+"@heroku/project-descriptor@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@heroku/project-descriptor/-/project-descriptor-0.0.6.tgz#5337e7243423b283d0a032dcff25035756341095"
+  integrity sha512-zH1Wx5WQFCnt3ToiQJ9yUWsOXN5woTiGczGUpvQS0zCwwkE42ydKZSRKgSlB/YIwsDmAkFKiUwe97fT+qP45iw==
+  dependencies:
+    ajv "^8.0.0"
+    ajv-formats "^2.0.2"
+    toml "^3.0.0"
+
+"@hk/functions-core@npm:@heroku/functions-core@0.2.8":
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/@heroku/functions-core/-/functions-core-0.2.8.tgz#4f8cb2ea8af1b3e6ab390c97a56aa81d1195dcac"
+  integrity sha512-7SDXh4PowdqXh2lmQxDtsBYvF4CU9qU5f4PAVIlg+PHBy5eM4VobfXtwjWmdAt6ISnxDOgr/49VVvVHR8f0yOQ==
   dependencies:
     "@heroku-cli/color" "^1.1.14"
     "@heroku/project-descriptor" "0.0.5"
     "@salesforce/core" "^2.20.10"
-    "@salesforce/templates" "^52.0.0"
+    "@salesforce/templates" "^54.2.0"
     "@salesforce/ts-sinon" "^1.3.12"
     axios "^0.21.2"
     cloudevents "^4.0.2"
@@ -462,15 +480,6 @@
     semver "^7.3.5"
     sha256-file "^1.0.0"
     yeoman-environment "~3.3.0"
-
-"@heroku/project-descriptor@0.0.5":
-  version "0.0.5"
-  resolved "https://registry.npmjs.org/@heroku/project-descriptor/-/project-descriptor-0.0.5.tgz#1a305bee7f4d9722818cd5fee2919d7d83953ddb"
-  integrity sha512-E5+MustRcw29xLeHJ1XZubMJDMJOrN1ge20/2/0/ZAwYV2ncD10wcmOLU8G92WY4ZLzX3T1t6/aOtDbQU61zXA==
-  dependencies:
-    ajv "^8.0.0"
-    ajv-formats "^2.0.2"
-    toml "^3.0.0"
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
@@ -1439,7 +1448,7 @@
     applicationinsights "^1.4.0"
     axios "^0.27.2"
 
-"@salesforce/templates@^52.0.0", "@salesforce/templates@^54.3.0", "@salesforce/templates@^54.6.0":
+"@salesforce/templates@^54.2.0", "@salesforce/templates@^54.3.0", "@salesforce/templates@^54.6.0":
   version "54.6.0"
   resolved "https://registry.yarnpkg.com/@salesforce/templates/-/templates-54.6.0.tgz#efe6117b1f3da09e5b4d731fd1e5102eddc5c1da"
   integrity sha512-zvVyKzgj/VCsiODh2ctnDbp9qV3K32g1JvNFfsatZpHd5VCruda27Pg1ecq7fiyT+cBqjTe4mrdwzl4995oIMQ==
@@ -1507,17 +1516,17 @@
     open "^8.4.0"
     tslib "^2"
 
-"@sf/functions@npm:@salesforce/plugin-functions@1.7.1":
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/plugin-functions/-/plugin-functions-1.7.1.tgz#0d802f87ddb07decf81c56580ebcfff327ac6272"
-  integrity sha512-1xvcY9i1v6BtN55zwqf1XLHDlNbHMnlENU1vRFk/n7n0UY07ehRUNQdZnXZS1jRnrpFVD3DiojKg14dhrJNT8A==
+"@sf/functions@npm:@salesforce/plugin-functions@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/plugin-functions/-/plugin-functions-1.11.1.tgz#d8b7222e2d73243d820a2ca3374e4b9b0c805493"
+  integrity sha512-ABB5yQCmRh5VfBEucUptSHNBvx5aiJSTNCzlFkGPMLkkR3gPCdaLf1JNDBysnT1MrLAXZFN5ywy4UTcII8W4SQ==
   dependencies:
     "@heroku-cli/color" "^1.1.14"
     "@heroku-cli/schema" "^1.0.25"
     "@heroku/eventsource" "^1.0.7"
     "@heroku/function-toml" "^0.0.3"
-    "@heroku/functions-core" "0.2.6"
-    "@heroku/project-descriptor" "0.0.5"
+    "@heroku/project-descriptor" "0.0.6"
+    "@hk/functions-core" "npm:@heroku/functions-core@0.2.8"
     "@oclif/core" "^1.6.0"
     "@salesforce/core" "^3.8.0"
     "@salesforce/plugin-org" "^1.11.2"


### PR DESCRIPTION
### What does this PR do?

This PR updates `plugin-functions` to the latest release. It's pretty far out of date at present, so the out of the box experience for functions isn't ideal.

### Acceptance Criteria

- Run `sf generate function -n myfunction -l javascript`
- Check that `cat functions/myfunction/project.toml` includes `salesforce-api-version = "54.0"`. Prior to this PR, this command generates a function with `salesforce-api-version = "53.0"`.

### What issues does this PR fix or reference?

- https://github.com/heroku/builder/pull/263#issuecomment-1154851050


### Other thoughts

Shouldn't dependabot have done this for us?