### PR TITLE
chore(deps): bump @sf/functions to 1.13.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@sf/config": "npm:@salesforce/plugin-config@2.3.2",
     "@sf/deploy-retrieve": "npm:@salesforce/plugin-deploy-retrieve@1.5.2",
     "@sf/env": "npm:@salesforce/plugin-env@1.5.0",
-    "@sf/functions": "npm:@salesforce/plugin-functions@1.13.1",
+    "@sf/functions": "npm:@salesforce/plugin-functions@1.13.4",
     "@sf/gen": "npm:@salesforce/plugin-generate@1.0.14",
     "@sf/info": "npm:@salesforce/plugin-info@2.0.1",
     "@sf/login": "npm:@salesforce/plugin-login@1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1531,10 +1531,10 @@
     open "^8.4.0"
     tslib "^2"
 
-"@sf/functions@npm:@salesforce/plugin-functions@1.13.1":
-  version "1.13.1"
-  resolved "https://registry.npmjs.org/@salesforce/plugin-functions/-/plugin-functions-1.13.1.tgz"
-  integrity sha512-38io+EuHeAmdk1UDQzoQftcoIwv1/hScN+BGyBa06I6dUvsyZV/1MgJwgegm1BdLyTeGBR1rx14n4iixpOyhXw==
+"@sf/functions@npm:@salesforce/plugin-functions@1.13.4":
+  version "1.13.4"
+  resolved "https://registry.yarnpkg.com/@salesforce/plugin-functions/-/plugin-functions-1.13.4.tgz#8cba3331f3a91810d2134acc7903c2f3e6641b3d"
+  integrity sha512-TEqKhHq1iCbkXJeiSsN4E1+ngjZO0/0Zxf8r23hFdupk6yR4eEWZoKCctVLrZtIcZZq9xjPt9omCnT1LX2LDTw==
   dependencies:
     "@heroku-cli/color" "^1.1.14"
     "@heroku-cli/schema" "^1.0.25"
@@ -7517,7 +7517,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
   resolved "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz"
   integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
 
-npm-package-arg@^8.0.0, npm-package-arg@^8.0.1, npm-package-arg@^8.1.0, npm-package-arg@^8.1.2, npm-package-arg@^8.1.4, npm-package-arg@^8.1.5:
+npm-package-arg@^8.0.0, npm-package-arg@^8.0.1, npm-package-arg@^8.1.0, npm-package-arg@^8.1.1, npm-package-arg@^8.1.2, npm-package-arg@^8.1.5:
   version "8.1.5"
   resolved "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.5.tgz"
   integrity sha512-LhgZrg0n0VgvzVdSm1oiZworPbTxYHUJCgtsJW8mGvlDpxTM1vSJc3m5QZeUkhAHIzbz3VCHd/R4osi1L1Tg/Q==
@@ -8072,7 +8072,7 @@ package-hash@^4.0.0:
     lodash.flattendeep "^4.4.0"
     release-zalgo "^1.0.0"
 
-pacote@^11.1.11, pacote@^11.2.6, pacote@^11.3.1, pacote@^11.3.4, pacote@^11.3.5:
+pacote@^11.1.11, pacote@^11.2.6, pacote@^11.3.0, pacote@^11.3.1, pacote@^11.3.5:
   version "11.3.5"
   resolved "https://registry.npmjs.org/pacote/-/pacote-11.3.5.tgz"
   integrity sha512-fT375Yczn4zi+6Hkk2TBe1x1sP8FgFsEIZ2/iWaXY2r/NkhDJfxbcn5paz1+RTFCyNf+dPnaoBDJoAxXSU8Bkg==


### PR DESCRIPTION
### What does this PR do?

Bumps  @sf/functions to 1.13.4

This releases --json flag fixes

### Acceptance Criteria

This change is largely a refactor of existing --json work but fixes the help output and solidifies the command schema.

### Testing Notes
_Anything additional to note about testing this PR. How did you test it? Special setup? Additional manual test cases? Things not tested?_

N/a

### Checklist
- [x] This change has been approved by the CLI Review Board or approval isn't required. Anything that adds/changes/deletes commands, flags, output, or json output has to be reviewed.
- [x] Does this follow the [deprecation policy](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_cli_deprecation.htm)?

### What issues does this PR fix or reference?

N/a
