### PR TITLE
chore: update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: 'weekly'
+    versioning-strategy: 'increase'
     labels:
       - "dependencies"
     open-pull-requests-limit: 100


### PR DESCRIPTION
### What does this PR do?
Updates the dependabot schedule to weekly so that it matches our release cadence and changes the versioning strategy so it will also update the package.json instead of just the yarn.lock

### Checklist
- [x] This change has been approved by the CLI Review Board or approval isn't required. Anything that adds/changes/deletes commands, flags, output, or json output has to be reviewed.
- [x] Does this follow the [deprecation policy](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_cli_deprecation.htm)?

### What issues does this PR fix or reference?
[[skip-validate-pr]]