### PR TITLE
chore: explicitly set yarn v1 as the packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
+  "packageManager": "yarn@1.22.19",
   "files": [
     "/bin",
     "/dist/**/*.js",


### PR DESCRIPTION
### What does this PR do?
This repository currently uses Yarn v1, however since no Yarn version is defined, if I run newer `yarn` locally it auto-migrates the repository to Yarn v3's new style lockfile and configuration.

Until such time as this project is migrated officially (which likely depends on Dependabot supporting Yarn 2/3), the Yarn v1 should be specified explicitly in `package.json`.

### Checklist
- [x] This change has been approved by the CLI Review Board or approval isn't required. Anything that adds/changes/deletes commands, flags, output, or json output has to be reviewed.
- [x] Does this follow the [deprecation policy](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_cli_deprecation.htm)?

### What issues does this PR fix or reference?

GUS-W-11739370.