### PR TITLE
chore: git2gus assigns work items to Platform CLI

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -1,6 +1,6 @@
 {
-  "productTag": "a1aAH00000004XFYAY",
-  "defaultBuild": "sf.r1.preprod",
+  "productTag": "a1aB00000004Bx8IAE",
+  "defaultBuild": "offcore.tooling.56",
   "issueTypeLabels": { "feature": "USER STORY", "regression": "BUG P1", "bug": "BUG P3" },
   "hideWorkItemUrl": true,
   "statusWhenClosed": "CLOSED"


### PR DESCRIPTION
### What does this PR do?
Configures Git2GUS to assign WIs to the Platform CLI team.

### What issues does this PR fix or reference?
@W-11989115@