### PR TITLE
Release PR for 1.62.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/cli",
   "description": "The Salesforce CLI",
-  "version": "1.62.1",
+  "version": "1.62.2",
   "author": "Salesforce",
   "bin": {
     "sf": "./bin/run"


### PR DESCRIPTION
The last release GHA did not trigger after merging, I think it might have been because I had a "don't run ci" commit tag on a trivial commit in it. Testing without.