### PR TITLE
chore: let builds scripts update plugins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,8 @@ updates:
     pull-request-branch-name:
       separator: "-"
     ignore:      
+      - dependency-name: '@salesforce/dev-scripts'
+      - dependency-name: "@salesforce/plugin-*"
+      - dependency-name: "@oclif/plugin-*"
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,20 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
       interval: 'weekly'
     versioning-strategy: 'increase'
     labels:
-      - "dependencies"
+      - 'dependencies'
     open-pull-requests-limit: 5
     pull-request-branch-name:
-      separator: "-"
-    ignore:      
+      separator: '-'
+    ignore:
       - dependency-name: '@salesforce/dev-scripts'
-      - dependency-name: "@salesforce/plugin-*"
-      - dependency-name: "@oclif/plugin-*"
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+      - dependency-name: '@salesforce/plugin-*'
+      - dependency-name: '@oclif/plugin-*'
+      - dependency-name: '@oclif/core'
+      - dependency-name: '@salesforce/core'
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "tslib": "^2.4.1"
   },
   "pinnedDependencies": [
+    "@oclif/core",
     "@oclif/plugin-autocomplete",
     "@oclif/plugin-commands",
     "@oclif/plugin-help",

--- a/package.json
+++ b/package.json
@@ -163,11 +163,13 @@
     "@salesforce/plugin-limits",
     "@salesforce/plugin-login",
     "@salesforce/plugin-org",
+    "@salesforce/plugin-schema",
     "@salesforce/plugin-settings",
     "@salesforce/plugin-sobject",
     "@salesforce/plugin-telemetry",
     "@salesforce/plugin-templates",
     "@salesforce/plugin-trust",
+    "@salesforce/sf-plugins-core",
     "@salesforce/plugin-user"
   ],
   "resolutions": {


### PR DESCRIPTION
### What does this PR do?
dependabot config won't bump plugins (oclif or salesforcecli) since build scripts do that.
