### PR TITLE
Remove functions from deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
     "@salesforce/plugin-data": "2.3.6",
     "@salesforce/plugin-deploy-retrieve": "1.8.2",
     "@salesforce/plugin-env": "2.1.2",
-    "@salesforce/plugin-functions": "1.21.2",
     "@salesforce/plugin-info": "2.6.0",
     "@salesforce/plugin-limits": "2.3.8",
     "@salesforce/plugin-login": "1.2.2",


### PR DESCRIPTION
### What does this PR do?
Removes `plugin-functions` from `dependencies` since it was added to JIT.
RC build failed https://github.com/salesforcecli/cli/actions/runs/4428410716/jobs/7767450476#step:7:37

### What issues does this PR fix or reference?
[skip-validate-pr]