### PR TITLE
chore: adjust crons

### DIFF
--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -2,7 +2,7 @@ name: automerge
 on:
   workflow_dispatch:
   schedule:
-    - cron: '23 2,5,8,11 * * *'
+    - cron: '23 1,4,7,10 * * *'
 
 jobs:
   automerge:


### PR DESCRIPTION
### What does this PR do?
Adjusting dependabot cron to prevent collisions with `nightly` automerge

### What issues does this PR fix or reference?
[skip-validate-pr]