### PR TITLE
Empty release flag

### DIFF
--- a/.github/workflows/make-pr-for-release.yml
+++ b/.github/workflows/make-pr-for-release.yml
@@ -31,7 +31,11 @@ on:
         description: '[--jit] Bump the versions of the packages listed in the "jitPlugins" (just-in-time) section'
       only:
         type: string
-        description: '[--only] Comma-separated list, no spaces, of dependencies that you want to bump'
+        description: '[--only] Comma-separated list (no spaces) of dependencies that you want to bump'
+      empty:
+        type: boolean
+        default: false
+        description: '[--empty] Create an empty release PR for pushing changes to later (version will still be bumped)'
 
 jobs:
   make-pr:


### PR DESCRIPTION
### What does this PR do?
Adds an `--empty` flag for creating an empty release PR. Useful for creating a PR to push changes to later.

### What issues does this PR fix or reference?
[@W-13082275@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-13082275)