### PR TITLE
ci: prereleases can have slashes in their branch names

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - release-base/*
+      - release-base/**
     types:
       - closed
 

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -6,7 +6,7 @@ on:
     # only applies to PRs that intent to be released to the public
     branches:
       - main
-      - release-base/*
+      - release-base/**
 
 jobs:
   validate-pr:


### PR DESCRIPTION
release-base/foo/bar