### PR TITLE
chore: docker node version update

### DIFF
--- a/.github/workflows/update-docker-node-version.yml
+++ b/.github/workflows/update-docker-node-version.yml
@@ -15,7 +15,7 @@ jobs:
           token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
       - uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: ${{ vars.TARBALL_NODE_VERSION }}
           cache: yarn
       - run: yarn install
       - run: node ./dockerfiles/update-docker-node-version.js

--- a/dockerfiles/update-docker-node-version.js
+++ b/dockerfiles/update-docker-node-version.js
@@ -15,15 +15,19 @@ const execPromise = promisify(execSync);
 
 (async () => {
   // Get the node version from `process.versions`
+  // Note that in GHA, this can be overwritten with the TARBALL_NODE_VERSION variable
+  // https://github.com/salesforcecli/cli/settings/variables/actions
+
   // This matches the default for oclif tarball node versions
   // https://github.com/oclif/oclif/blob/main/src/tarballs/config.ts#L56
-  const nodeMajor = process.versions.node.split('.')[0];
+  const nodeVersion = process.versions.node;
 
-  const url = `https://nodejs.org/dist/latest-v${nodeMajor}.x/SHASUMS256.txt`;
+  // Example url: https://nodejs.org/dist/v18.15.0/
+  const url = `https://nodejs.org/dist/v${nodeVersion}/SHASUMS256.txt`;
   console.log('Retrieving SHA data from:', url);
 
   const distData = await got(url).text();
-  const distRegex = new RegExp(`^([A-z0-9]+)  (node-(v${nodeMajor}.[0-9]+.[0-9]+)-linux-x64.tar.gz)$`, 'm');
+  const distRegex = new RegExp(`^([A-z0-9]+)  (node-(v${nodeVersion})-linux-x64.tar.gz)$`, 'm');
 
   const [, sha, tar, version] = distRegex.exec(distData);
 


### PR DESCRIPTION
### What does this PR do?
Allows you to set the node version to be used via GHA env vars

### What issues does this PR fix or reference?
[skip-validate-pr]
Similar to https://github.com/salesforcecli/sfdx-cli/pull/1169