### PR TITLE
chore: increase index because nightlies

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "update": {
       "s3": {
         "bucket": "dfc-data-production",
-        "indexVersionLimit": 20,
+        "indexVersionLimit": 140,
         "folder": "media/salesforce-cli/sf",
         "acl": " ",
         "host": "https://developer.salesforce.com"


### PR DESCRIPTION
Now that we have `nightlies` we need to increase the number of versions that we keep on the version index. 

[skip-validate-pr]