### PR TITLE
chore: use SF_ for hiding release notes

### DIFF
--- a/.github/workflows/make-pr-for-nightly.yml
+++ b/.github/workflows/make-pr-for-nightly.yml
@@ -20,8 +20,7 @@ jobs:
   make-pr-for-nightly:
     env:
       GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
-      # TODO: Add support for SF_ env vars in plugin-info and replace it here.
-      SFDX_HIDE_RELEASE_NOTES: true
+      SF_HIDE_RELEASE_NOTES: true
     runs-on: 'ubuntu-latest'
     steps:
       - name: Check out repository as our bot user

--- a/.github/workflows/make-pr-for-release.yml
+++ b/.github/workflows/make-pr-for-release.yml
@@ -37,8 +37,7 @@ jobs:
   make-pr:
     env:
       GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
-      # TODO: Add support for SF_ env vars in plugin-info and replace it here.
-      SFDX_HIDE_RELEASE_NOTES: true
+      SF_HIDE_RELEASE_NOTES: true
     runs-on: 'ubuntu-latest'
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/v2-make-pr-for-nightly.yml
+++ b/.github/workflows/v2-make-pr-for-nightly.yml
@@ -21,7 +21,7 @@ jobs:
   v2-make-pr-for-nightly:
     env:
       GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
-      SFDX_HIDE_RELEASE_NOTES: true
+      SF_HIDE_RELEASE_NOTES: true
     runs-on: 'ubuntu-latest'
     steps:
       - name: Check out repository as our bot user

--- a/scripts/post-install-release-notes.js
+++ b/scripts/post-install-release-notes.js
@@ -3,7 +3,7 @@
 const { spawn } = require('child_process');
 const { join } = require('path');
 
-if (process.env.SFDX_HIDE_RELEASE_NOTES === 'true' || process.env.SF_HIDE_RELEASE_NOTES === 'true') process.exit(0);
+if (process.env.SF_HIDE_RELEASE_NOTES === 'true') process.exit(0);
 
 const logAndExit = (msg) => {
   console.log('NOTE: This error can be ignored in CI and may be silenced in the future');

--- a/src/hooks/display-release-notes.ts
+++ b/src/hooks/display-release-notes.ts
@@ -22,7 +22,7 @@ const logError = (msg: Error): void => {
 
 const hook: Hook.Update = async (): Promise<void> =>
   new Promise((resolve) => {
-    if (process.env.SFDX_HIDE_RELEASE_NOTES === 'true' || process.env.SF_HIDE_RELEASE_NOTES === 'true') {
+    if (process.env.SF_HIDE_RELEASE_NOTES === 'true') {
       resolve();
     }
 


### PR DESCRIPTION
### What does this PR do?
Checks `SF_` env vars for hiding release notes, updates github actions
Related to: https://github.com/salesforcecli/plugin-info/pull/422

### What issues does this PR fix or reference?
@W-13171024@