### PR TITLE
chore: remove v2 changelogs

### DIFF
--- a/.github/workflows/v2-create-github-release.yml
+++ b/.github/workflows/v2-create-github-release.yml
@@ -44,22 +44,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
-
-      - name: Conventional Changelog Action
-        id: changelog
-        uses: TriPSs/conventional-changelog-action@d360fad3a42feca6462f72c97c165d60a02d4bf2
-        # overriding some of the basic behaviors to just get the changelog
-        with:
-          git-user-name: svc-cli-bot
-          git-user-email: svc_cli_bot@salesforce.com
-          github-token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
-          output-file: false
-          # always do the release, even if there are no semantic commits
-          skip-on-empty: false
-          # pjson version was already updated by the "cli:release:build" script, so don't base behavior on these commits
-          skip-version-file: true
-          # avoids the default `v` so all the later actions don't have to remove it
-          tag-prefix: ''
       - uses: notiz-dev/github-action-json-property@2192e246737701f108a4571462b76c75e7376216
         id: packageVersion
         with:
@@ -77,6 +61,3 @@ jobs:
           # NOTES: Again, here we are defaulting to 'beta' for the v2 branch
           body: |
             !! Release as beta !!
-
-            Change log:
-            ${{ steps.changelog.outputs.clean_changelog }}

--- a/.github/workflows/workflow-failure.yml
+++ b/.github/workflows/workflow-failure.yml
@@ -11,6 +11,9 @@ on:
       - promote
       - promote-nightly-to-rc
       - promote-rc-to-latest
+      - v2-create-github-release
+      - v2-automerge-nightly-pr
+      - v2-make-pr-for-nightly
     types:
       - completed
 


### PR DESCRIPTION
### What does this PR do?
Removes change logs on the v2 branch since they are not needed. See https://github.com/salesforcecli/sfdx-cli/pull/1267
Also adds the v2 workflows to failure notifications 

### What issues does this PR fix or reference?
[@W-13660199@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-13660199)