### PR TITLE
Update release notes url

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "info": {
       "releasenotes": {
         "distTagUrl": "https://registry.npmjs.org/-/package/@salesforce/cli/dist-tags",
-        "releaseNotesPath": "https://github.com/forcedotcom/cli/tree/main/releasenotes/sf",
+        "releaseNotesPath": "https://github.com/forcedotcom/cli/tree/main/releasenotes",
         "releaseNotesFilename": "README.md"
       }
     },


### PR DESCRIPTION
### What does this PR do?
Updates the url for the sf v2 release notes. A draft already exists here https://github.com/forcedotcom/cli/blob/01284fb16a955d9a15b86307a04aad1c9db3ee80/releasenotes/README.md

### What issues does this PR fix or reference?
[skip-validate-pr]
