### PR TITLE
remove check for v2 GA

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -117,9 +117,7 @@ jobs:
 
   docker-promote:
     needs: [open-ctc-or-skip, get-package-info]
-    # TODO: remove for v2 GA
-    # if: success()
-    if: success() && !contains(inputs.new-channel, 'latest') && !contains(inputs.new-channel , 'stable')
+    if: success()
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo


### PR DESCRIPTION
### What does this PR do?
Removes a check for docker promotions to allow sf v2 to promote

[skip-validate-pr]