### PR TITLE
fix: temporary support for container mode for vscode

### DIFF
--- a/dockerfiles/Dockerfile_full
+++ b/dockerfiles/Dockerfile_full
@@ -21,5 +21,6 @@ RUN apt-get autoremove --assume-yes \
   && rm -rf /var/lib/apt/lists/*
 
 ENV SF_CONTAINER_MODE true
+ENV SFDX_CONTAINER_MODE true
 ENV DEBIAN_FRONTEND=dialog
 ENV SHELL /bin/bash

--- a/dockerfiles/Dockerfile_slim
+++ b/dockerfiles/Dockerfile_slim
@@ -18,5 +18,6 @@ RUN apt-get autoremove --assume-yes \
 
 ENV PATH="/usr/local/sf/bin:$PATH"
 ENV SF_CONTAINER_MODE true
+ENV SFDX_CONTAINER_MODE true
 ENV DEBIAN_FRONTEND=dialog
 ENV SHELL /bin/bash


### PR DESCRIPTION
### What does this PR do?
vscode uses an old env.  this will help until they change it.

https://github.com/forcedotcom/salesforcedx-vscode/issues/5003