### PR TITLE
chore: pass along --empty

### DIFF
--- a/.github/workflows/make-pr-for-release.yml
+++ b/.github/workflows/make-pr-for-release.yml
@@ -63,3 +63,4 @@ jobs:
             ${{ inputs.start-from-npm-dist-tag && format('--start-from-npm-dist-tag {0}', inputs.start-from-npm-dist-tag) || '' }} \
             ${{ inputs.patch && '--patch' || '' }} \
             ${{ inputs.only && format('--only {0}', inputs.only) || '' }}
+            ${{ inputs.empty && '--empty' || '' }} \


### PR DESCRIPTION
Passes along the `--empty` boolean to https://github.com/salesforcecli/plugin-release-management/blob/main/src/commands/cli/release/build.ts#L155

[skip-validate-pr]