### PR TITLE
feat: add version diff prerun hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "hooks": {
       "command_incomplete": "./dist/hooks/incomplete",
       "plugins:preinstall": "./dist/hooks/pluginsPreinstall.js",
-      "update": "./dist/hooks/display-release-notes.js"
+      "update": "./dist/hooks/display-release-notes.js",
+      "prerun": "./dist/hooks/prerun"
     },
     "update": {
       "s3": {

--- a/src/hooks/prerun.ts
+++ b/src/hooks/prerun.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Hook, ux } from '@oclif/core';
+
+// eslint-disable-next-line @typescript-eslint/require-await
+const hook: Hook.Prerun = async function ({ config }) {
+  const jitPlugins = config.pjson.oclif.jitPlugins ?? {};
+  const deps = config.pjson.dependencies ?? {};
+  for (const plugin of config.getPluginsList()) {
+    // Skip the root plugin
+    if (plugin.root === config.root) continue;
+    // Skip user plugins that are not in the jitPlugins configuration
+    if (plugin.type === 'user' && !jitPlugins[plugin.name]) continue;
+    // Skip linked plugins
+    if (plugin.type === 'link') continue;
+
+    const specifiedVersion = jitPlugins[plugin.name] ?? deps[plugin.name];
+    if (plugin.version !== specifiedVersion) {
+      ux.warn(
+        `Plugin ${plugin.name} (${plugin.version}) differs from the version specified by ${config.bin} (${specifiedVersion})`
+      );
+    }
+  }
+};
+
+export default hook;

--- a/src/hooks/prerun.ts
+++ b/src/hooks/prerun.ts
@@ -8,23 +8,21 @@
 import { Hook, ux } from '@oclif/core';
 
 // eslint-disable-next-line @typescript-eslint/require-await
-const hook: Hook.Prerun = async function ({ config }) {
+const hook: Hook.Prerun = async function ({ Command, config }) {
+  const { plugin } = Command;
+  if (!plugin) return;
+  if (plugin.type === 'link') return;
+
   const jitPlugins = config.pjson.oclif.jitPlugins ?? {};
   const deps = config.pjson.dependencies ?? {};
-  for (const plugin of config.getPluginsList()) {
-    // Skip the root plugin
-    if (plugin.root === config.root) continue;
-    // Skip user plugins that are not in the jitPlugins configuration
-    if (plugin.type === 'user' && !jitPlugins[plugin.name]) continue;
-    // Skip linked plugins
-    if (plugin.type === 'link') continue;
 
-    const specifiedVersion = jitPlugins[plugin.name] ?? deps[plugin.name];
-    if (plugin.version !== specifiedVersion) {
-      ux.warn(
-        `Plugin ${plugin.name} (${plugin.version}) differs from the version specified by ${config.bin} (${specifiedVersion})`
-      );
-    }
+  const specifiedVersion = jitPlugins[plugin.name] ?? deps[plugin.name];
+  if (!specifiedVersion) return;
+
+  if (plugin.version !== specifiedVersion) {
+    ux.warn(
+      `Plugin ${plugin.name} (${plugin.version}) differs from the version specified by ${config.bin} (${specifiedVersion})`
+    );
   }
 };
 

--- a/src/hooks/prerun.ts
+++ b/src/hooks/prerun.ts
@@ -9,6 +9,7 @@ import { Hook, ux } from '@oclif/core';
 
 // eslint-disable-next-line @typescript-eslint/require-await
 const hook: Hook.Prerun = async function ({ Command, config }) {
+  if (process.argv.includes('--json')) return;
   const { plugin } = Command;
   if (!plugin) return;
   if (plugin.type === 'link') return;


### PR DESCRIPTION
### What does this PR do?
Adds prerun hook that will warn customers about user-installed plugins that differ from the version specified by sf. Warnings will only appear for the plugin that owns the command being run.

```
 ›   Warning: Plugin @salesforce/plugin-custom-metadata (2.2.0) differs from the version specified by sf (2.1.41)
```

### What issues does this PR fix or reference?
@W-14086486@