### PR TITLE
chore: increase automerge tries

### DIFF
--- a/.github/workflows/automerge-nightly-pr.yml
+++ b/.github/workflows/automerge-nightly-pr.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Automerge
         uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
         with:
-          max_attempts: 15
-          retry_wait_seconds: 120 # 15 attempts every two minutes
+          max_attempts: 30
+          retry_wait_seconds: 120 # 30 attempts every two minutes
           command: sf-release cli:release:automerge --owner salesforcecli --repo cli --pull-number ${{ github.event.pull_request.number }} --verbose
           retry_on: error
           timeout_minutes: 60


### PR DESCRIPTION
The new JIT installs on windows take a long time and the automerge has been reaching it max retries

[skip-validate-pr]