### PR TITLE
chore: remove @oclif/core from pinnedDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,6 @@
     "tslib": "^2.4.1"
   },
   "pinnedDependencies": [
-    "@oclif/core",
     "@oclif/plugin-autocomplete",
     "@oclif/plugin-commands",
     "@oclif/plugin-help",


### PR DESCRIPTION
### What does this PR do?

Remove `@oclif/core` from pinnedDependencies until https://github.com/salesforcecli/cli/pull/1094 is merged

### What issues does this PR fix or reference?
[skip-validate-pr]