### PR TITLE
chore: filter out ignored commands from search

### DIFF
--- a/src/hooks/incomplete.ts
+++ b/src/hooks/incomplete.ts
@@ -41,7 +41,10 @@ async function determineCommand(config: Interfaces.Config, matches: Command.Load
 }
 
 const hook: Hook.CommandIncomplete = async function ({ config, matches, argv }) {
-  const command = await determineCommand(config, matches);
+  const command = await determineCommand(
+    config,
+    matches.filter((m) => !m.hidden)
+  );
 
   if (argv.includes('--help') || argv.includes('-h')) {
     const Help = await loadHelpClass(config);


### PR DESCRIPTION
### What does this PR do?
hides hidden commands from the `incomplete_command` hook

e.g.

```
 ➜  sf package version      
? Which of these commands do you mean 
  package version list                List all package versions in the Dev Hub org. 
  package version promote             Promote a package version to released. 
  package version report              Retrieve details about a package version in the Dev Hub org. 
❯ package version retrieve            Retrieve package metadata for a specified package version. 
  package version update              Update a package version. 
  package version create              Create a package version in the Dev Hub org. 
```

`package version retrieve` should not appear in this list because the command is hidden

### Acceptance Criteria
the command doesn't appear

### Testing Notes

build, and run with `./bin/run.js package:version`

and then don't see `package version retrieve` in the list

### Checklist
- [x] This change has been approved by the CLI Review Board or approval isn't required. Anything that adds/changes/deletes commands, flags, output, or json output has to be reviewed.
- [x] Does this follow the [deprecation policy](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_cli_deprecation.htm)?

### What issues does this PR fix or reference?
@W-14189635@
