### PR TITLE
chore: set update available warning timeout to 7 days

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,10 @@
     ],
     "additionalHelpFlags": [
       "-h"
-    ]
+    ],
+    "warn-if-update-available": {
+      "timeoutInDays": 7
+    }
   },
   "dependencies": {
     "@oclif/core": "3.0.3",


### PR DESCRIPTION
### What does this PR do?
Sets the cache timeout for plugin-warn-if-update-available to 7 days (default is 60 days)

### What issues does this PR fix or reference?
[skip-validate-pr]