### PR TITLE
fix(debug): set default log level

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -31,6 +31,11 @@ export function preprocessCliFlags(process: ProcessLike): void {
       process.env.SF_DEBUG = '1';
       process.env.SF_ENV = 'development';
 
+      // set `SF_LOG_LEVEL` to `trace` if it wasn't specified
+      if (process.env.SF_LOG_LEVEL === undefined) {
+        process.env.SF_LOG_LEVEL = 'trace';
+      }
+
       // need to calculate indexOf --dev-debug here because it might've changed based on --debug-filter
       process.argv.splice(process.argv.indexOf('--dev-debug'), 1);
     }


### PR DESCRIPTION
### What does this PR do?
makes `--dev-debug` to set `SF_LOG_LEVEL=trace` if it's not set.

### before:
to get debug logs from oclif and logging output we need to set `--dev-debug` and `SF_LOG_LEVEL` env var

### after:
only `--dev-debug` is required. The default log level is `trace` so that all logger output is included.

### What issues does this PR fix or reference?
@W-14375066@