### PR TITLE
fix: add sf-plugins-core and oclif/core back to pinnedDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "debug": "^4.3.4"
   },
   "pinnedDependencies": [
+    "@oclif/core",
     "@oclif/plugin-autocomplete",
     "@oclif/plugin-commands",
     "@oclif/plugin-help",
@@ -168,6 +169,7 @@
     "@oclif/plugin-version",
     "@oclif/plugin-warn-if-update-available",
     "@oclif/plugin-which",
+    "@salesforce/sf-plugins-core",
     "@salesforce/plugin-apex",
     "@salesforce/plugin-auth",
     "@salesforce/plugin-data",


### PR DESCRIPTION
### What does this PR do?
`sf-plugins-core` and `oclif/core` were dropped from `pinnedDependencies` just before we released their latest major versions to avoid them being bumped before the ESM migration branch was merged. Now that it has been merged, we can add them back to `pinnedDependencies`

### What issues does this PR fix or reference?
[skip-validate-pr]
