### PR TITLE
chore: swap got, move docker update to same job

### DIFF
--- a/.github/workflows/make-pr-for-nightly.yml
+++ b/.github/workflows/make-pr-for-nightly.yml
@@ -89,8 +89,17 @@ jobs:
         # If the package.json 'minor' IS GREATER THAN the latest-rc 'minor', we want to bump 'patch'
         if: ${{ steps.package-json-semver-info.outputs.minor > steps.latest-rc-semver-info.outputs.minor }}
 
-  update-docker-node-version:
-    needs: make-pr-for-nightly
-    # TODO: We could convert this to an Action to avoid node-setup duplication and separate `job`
-    # Set the node version in the Dockerfile_full image for this release
-    uses: ./.github/workflows/update-docker-node-version.yml
+      - name: Update node version in dockerfile_full
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
+        with:
+          command: node ./dockerfiles/update-docker-node-version.cjs
+
+      # Push Dockerfile changes if 'git status' is not empty
+      - run: |
+          if [[ -n $(git status --short) ]]; then
+            git add dockerfiles/Dockerfile_full
+            git commit -m "chore: update node in dockerfile_full" --no-verify
+            git push --no-verify
+          else
+            echo "Already up to date"
+          fi

--- a/.github/workflows/make-pr-for-release.yml
+++ b/.github/workflows/make-pr-for-release.yml
@@ -68,8 +68,17 @@ jobs:
             ${{ inputs.only && format('--only {0}', inputs.only) || '' }} \
             ${{ inputs.empty && '--empty' || '' }}
 
-  update-docker-node-version:
-    needs: make-pr
-    # TODO: We could convert this to an Action to avoid node-setup duplication and separate `job`
-    # Set the node version in the Dockerfile_full image for this release
-    uses: ./.github/workflows/update-docker-node-version.yml
+      - name: Update node version in dockerfile_full
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
+        with:
+          command: node ./dockerfiles/update-docker-node-version.cjs
+
+      # Push Dockerfile changes if 'git status' is not empty
+      - run: |
+          if [[ -n $(git status --short) ]]; then
+            git add dockerfiles/Dockerfile_full
+            git commit -m "chore: update node in dockerfile_full" --no-verify
+            git push --no-verify
+          else
+            echo "Already up to date"
+          fi

--- a/.github/workflows/update-docker-node-version.yml
+++ b/.github/workflows/update-docker-node-version.yml
@@ -12,7 +12,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ vars.NODE_VERSION_OVERRIDE || 'lts/*' }}
-      - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
       - name: Update node version in dockerfile_full
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:

--- a/dockerfiles/update-docker-node-version.cjs
+++ b/dockerfiles/update-docker-node-version.cjs
@@ -5,7 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-const got = require('got');
 const fs = require('fs').promises;
 const path = require('path');
 
@@ -26,7 +25,7 @@ const execPromise = promisify(execSync);
   const url = `https://nodejs.org/dist/v${nodeVersion}/SHASUMS256.txt`;
   console.log('Retrieving SHA data from:', url);
 
-  const distData = await got(url).text();
+  const distData = await execPromise(`curl -s ${url}`);
   const distRegex = new RegExp(`^([A-z0-9]+)  (node-(v${nodeVersion})-linux-x64.tar.gz)$`, 'm');
 
   const [, sha, tar, version] = distRegex.exec(distData);

--- a/dockerfiles/update-docker-node-version.cjs
+++ b/dockerfiles/update-docker-node-version.cjs
@@ -25,7 +25,7 @@ const execPromise = promisify(execSync);
   const url = `https://nodejs.org/dist/v${nodeVersion}/SHASUMS256.txt`;
   console.log('Retrieving SHA data from:', url);
 
-  const distData = await execPromise(`curl -s ${url}`);
+  const distData = (await execPromise(`curl -s ${url}`)).stdout;
   const distRegex = new RegExp(`^([A-z0-9]+)  (node-(v${nodeVersion})-linux-x64.tar.gz)$`, 'm');
 
   const [, sha, tar, version] = distRegex.exec(distData);


### PR DESCRIPTION
Needed to ensure the docker update steps were in the same `job` so that the changes were pushed to the branch created by the previous steps. 

Swapped `got` for `exec` to eliminate the need for a `yarn install`. 

[@W-14338799@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-14338799)