### PR TITLE
chore: empty var does not invoke input default

### DIFF
--- a/.github/workflows/create-cli-release.yml
+++ b/.github/workflows/create-cli-release.yml
@@ -45,7 +45,7 @@ jobs:
     with:
       tag: ${{ needs.get-channel.outputs.channel }}
       githubTag: ${{ github.event.release.tag_name }}
-      nodeVersion: ${{ vars.NODE_VERSION_OVERRIDE }} # default is 'lts/*'
+      nodeVersion: ${{ vars.NODE_VERSION_OVERRIDE || 'lts/*' }}
 
   pack-verify-upload-tarballs:
     needs: [get-channel, npm-release]
@@ -55,7 +55,7 @@ jobs:
       cli: sf
       version: ${{ github.event.release.tag_name }}
       channel: ${{ needs.get-channel.outputs.s3-channel }}
-      nodeVersion: ${{ vars.NODE_VERSION_OVERRIDE }} # default is 'lts/*'
+      nodeVersion: ${{ vars.NODE_VERSION_OVERRIDE || 'lts/*' }}
     secrets: inherit
 
   archives-verify:
@@ -90,7 +90,7 @@ jobs:
       cli: sf
       version: ${{ github.event.release.tag_name }}
       channel: ${{ needs.get-channel.outputs.s3-channel }}
-      nodeVersion: ${{ vars.NODE_VERSION_OVERRIDE }} # default is 'lts/*'
+      nodeVersion: ${{ vars.NODE_VERSION_OVERRIDE || 'lts/*' }}
     secrets: inherit
 
   pack-upload-win:
@@ -100,7 +100,7 @@ jobs:
       cli: sf
       version: ${{ github.event.release.tag_name }}
       channel: ${{ needs.get-channel.outputs.s3-channel }}
-      nodeVersion: ${{ vars.NODE_VERSION_OVERRIDE }} # default is 'lts/*'
+      nodeVersion: ${{ vars.NODE_VERSION_OVERRIDE || 'lts/*' }}
     secrets: inherit
 
   stampy-upload-win:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
   tarballs:
     uses: salesforcecli/github-workflows/.github/workflows/tarballs.yml@main
     with:
-      nodeVersion: ${{ vars.NODE_VERSION_OVERRIDE }} # default is 'lts/*'
+      nodeVersion: ${{ vars.NODE_VERSION_OVERRIDE || 'lts/*' }}
     secrets: inherit
 
   # DONE


### PR DESCRIPTION
### What does this PR do?
I was trying to take advantage of `input` default on a workflow_call. However, apparently if a Repository Variable is not set, it still gets passed in as an empty string so the default is not used... This PR is explicit about the fallback (like we are everywhere else)

Example: https://github.com/salesforcecli/cli/actions/runs/6788841412/job/18455019175#step:1:47