### PR TITLE
Replace actions/create-release@v1

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -78,6 +78,7 @@ jobs:
         with:
           name: ${{ steps.packageVersion.outputs.prop }}
           tag: ${{ steps.packageVersion.outputs.prop }}
+          commit: ${{ github.ref_name }}
           # This channel value is read from the Github Release body to determine the channel. Be cautious editing
           body: |
             !! Release as ${{ needs.validate-channel.outputs.channel }} !!

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -74,13 +74,13 @@ jobs:
           path: 'package.json'
           prop_path: 'version'
       - name: Create Github Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+        uses: ncipollo/release-action@v1.13.0
         with:
-          tag_name: ${{ steps.packageVersion.outputs.prop }}
-          release_name: ${{ steps.packageVersion.outputs.prop }}
-          prerelease: ${{ !contains(fromJSON('["latest", "latest-rc", "nightly"]'), needs.validate-channel.outputs.channel) }}
+          name: ${{ steps.packageVersion.outputs.prop }}
+          tag: ${{ steps.packageVersion.outputs.prop }}
           # This channel value is read from the Github Release body to determine the channel. Be cautious editing
           body: |
             !! Release as ${{ needs.validate-channel.outputs.channel }} !!
+          prerelease: ${{ !contains(fromJSON('["latest", "latest-rc", "nightly"]'), needs.validate-channel.outputs.channel) }}
+          token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+          skipIfReleaseExists: true


### PR DESCRIPTION
The GHA `actions/create-release@v1` has been deprecated for a while. The PR replaces that action with a similar action

[@W-14488760@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-14488760)

### Example of this working
- PR: https://github.com/salesforcecli/cli/pull/1349
- Create release action: https://github.com/salesforcecli/cli/actions/runs/7038698855/job/19156176923#step:4:3
- Release: https://github.com/salesforcecli/cli/actions/runs/7038703648/job/19156196911#step:7:20
- Npm view dist-tags: 
```json
{
  "latest": "2.19.8",
  "latest-rc": "2.20.6",
  "nightly": "2.21.1",
  "beta": "2.0.0-beta.74",
  "legacy": "1.86.7-legacy.0",
  "dev": "2.20.6-dev.0", <-- yay
  "qa": "2.16.2-qa.0",
  "esm": "2.17.1-esm.0",
  "cjs": "2.13.2-cjs.1"
}
```