### PR TITLE
Ignore plugin-dev nuts on windows

### DIFF
--- a/.github/workflows/just-nuts.yml
+++ b/.github/workflows/just-nuts.yml
@@ -55,6 +55,9 @@ jobs:
           # - salesforce/plugin-functions
           # - salesforce/sfdx-plugin-lwc-test
           # - salesforce/sfdx-scanner
+        exclude:
+          - os: windows-latest
+            repository: salesforcecli/plugin-dev # These are flakey on Windows
     uses: ./.github/workflows/just-nut.yml
     with:
       repository: ${{matrix.repository}}


### PR DESCRIPTION
These have been flakey for a while, ignoring for now since we have not been able to replicate the error and have not received any external reports of this failing.

[skip-validate-pr]