### PR TITLE
chore: add example plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     ],
     "nsisCustomization": "scripts/nsis.nsi",
     "scope": "salesforce",
+    "examplePlugin": "@salesforce/plugin-packaging",
     "dirname": "sf",
     "topicSeparator": " ",
     "flexibleTaxonomy": true,


### PR DESCRIPTION
### What does this PR do?

Add `examplePlugin` to `oclif` config so that plugin-plugins can show it in help instead of `myplugin`

```
EXAMPLES
  Install a plugin from npm registry.

    $ sf plugins install @salesforce/plugin-packaging
```

### What issues does this PR fix or reference?
[skip-validate-pr]