### PR TITLE
Disable telemetry on jit smoke tests

### DIFF
--- a/.github/workflows/jit-install-smoke.yml
+++ b/.github/workflows/jit-install-smoke.yml
@@ -70,3 +70,5 @@ jobs:
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           command: yarn sf-release cli:install:jit:test --jit-plugin ${{matrix.jitPlugins}}
+        env:
+          SF_DISABLE_TELEMETRY: true


### PR DESCRIPTION
Disable telemetry on JIT smoke tests. We have disabled telemetry on other GHA workflows.

This will help lower the (inflated) error rate for `plugin-plugins` on `nightly` and `latest-rc` releases

<img width="1194" alt="Screenshot 2024-04-10 at 1 08 50 PM" src="https://github.com/salesforcecli/cli/assets/1715111/c04b907a-eb7e-4a2f-8754-0fa06d307ce3">
