### PR TITLE
Prevent a legacy release

### DIFF
--- a/.github/workflows/create-cli-release.yml
+++ b/.github/workflows/create-cli-release.yml
@@ -26,6 +26,13 @@ jobs:
           script: |
             core.setFailed('Release channel was not found in release body. Exiting')
 
+      - name: Prevent legacy channel
+        if: ${{ steps.release-channel.outputs.group1 == 'legacy' }}
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('Do not publish to the "legacy" channel! It is still bundled with "sfdx@v7", which is permanetly archived.')
+
       - name: Get release channel for s3
         id: s3-release-channel
         run: |

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -35,6 +35,13 @@ jobs:
           script: |
             core.setFailed('Release channel was not found in PR title. Exiting')
 
+      - name: Prevent legacy channel
+        if: ${{ steps.release-channel.outputs.group1 == 'legacy' }}
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('Do not publish to the "legacy" channel! It is still bundled with "sfdx@v7", which is permanetly archived.')
+
       # Checkout needed to validate prerelease version in package.json
       - name: Check out the repo
         if: ${{ !contains(fromJSON('["latest", "latest-rc", "nightly"]'), steps.release-channel.outputs.group1) }}


### PR DESCRIPTION
The `legacy` tag was used as the final `sf@v1` version that was bundled with `sfdx@v7`. Now that `sfdx-cli` is archived, we should prevent accidentally publishing a new legacy "prerelease". 