### PR TITLE
chore: remove resolutions so templates-beta ships

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,10 +207,7 @@
     "@salesforce/plugin-user"
   ],
   "resolutions": {
-    "@salesforce/schemas": "1.7.0",
-    "@salesforce/templates": "60.1.1",
-    "@salesforce/source-deploy-retrieve": "11.0.0",
-    "@salesforce/source-tracking": "6.0.0"
+    "@salesforce/schemas": "1.7.0"
   },
   "repository": "salesforcecli/cli",
   "scripts": {


### PR DESCRIPTION
we're using a beta release of templates in plugin-templates.  Resolutions was overriding that.

I'd rather let yarn/yarn-dedupe sort out SDR/STL requirements than yarn resolutions.  We bump those anyway

@W-15387805@