### PR TITLE
Fix use of spawn on windows

### DIFF
--- a/scripts/post-install-release-notes.js
+++ b/scripts/post-install-release-notes.js
@@ -22,9 +22,14 @@ async function main() {
     };
 
     const executable = isWindows ? 'run.cmd' : 'run.js';
-    // Since 20.12.2, it is invalid to call spawn on Windows with a .bat/.cmd file without using shell: true. 
-    const opts = isWindows ? { stdio: ['ignore', 'inherit', 'pipe'], timeout: 10000, shell:true } : { stdio: ['ignore', 'inherit', 'pipe'], timeout: 10000 }
-    const cmd = spawn(join(fileURLToPath(import.meta.url), '..', '..', 'bin', executable), ['whatsnew', '--hook'], opts);
+    // Since 20.12.2, it is invalid to call spawn on Windows with a .bat/.cmd file without using shell: true.
+    // https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V20.md#2024-04-10-version-20122-iron-lts-rafaelgss
+    const opts = { stdio: ['ignore', 'inherit', 'pipe'], timeout: 10000, ...(isWindows ? { shell: true } : {}) };
+    const cmd = spawn(
+      join(fileURLToPath(import.meta.url), '..', '..', 'bin', executable),
+      ['whatsnew', '--hook'],
+      opts
+    );
 
     cmd.stderr.on('data', (error) => {
       logAndExit(error);


### PR DESCRIPTION
### What does this PR do?
Following the 20.12.2 NodeJS LTS release, it is not allowed to call child_process.spawn without shell option enabled on Windows (CVE-2024-27980)
This PR include shell option in the post-install-release-notes.js file

### Acceptance Criteria
_How do you know this change is successful? What is the scope of this change? What tests test the criteria (or why no tests)?_

_The Acceptance Criteria can be copied from the work item if they exist there but it is useful to have on the PR when reviewing the code._

### Testing Notes
_Anything additional to note about testing this PR. How did you test it? Special setup? Additional manual test cases? Things not tested?_

### Checklist
- [ ] This change has been approved by the CLI Review Board or approval isn't required. Anything that adds/changes/deletes commands, flags, output, or json output has to be reviewed.
- [ ] Does this follow the [deprecation policy](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_cli_deprecation.htm)?

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2822
