### PR TITLE
chore: bump required node to 18.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/salesforcecli/cli",
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.6.0"
   },
   "packageManager": "yarn@1.22.19",
   "files": [


### PR DESCRIPTION
@W-14439471@

we might/should be able to bump to 20? since 18 is now in [maintenance](https://nodejs.org/en/about/previous-releases) 