### PR TITLE
ci: skip prm install after calling `yarn install`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,5 +39,4 @@ jobs:
           node-version: ${{ vars.NODE_VERSION_OVERRIDE || 'lts/*' }}
           cache: yarn
       - run: yarn install
-      - run: npm install -g @salesforce/plugin-release-management
       - run: yarn test:deprecation-policy


### PR DESCRIPTION
### What does this PR do?

don't globally install prm since it's not used (yarn install brings in the local equivalent)