### PR TITLE
fix: add json theme

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -12,5 +12,16 @@
   "sectionDescription": "none",
   "sectionHeader": "blue",
   "topic": "blueBright",
-  "version": "none"
+  "version": "none",
+  "json": {
+    "brace": "whiteBright",
+    "bracket": "whiteBright",
+    "colon": "none",
+    "comma": "green",
+    "key": "blue",
+    "string": "green",
+    "number": "blue",
+    "boolean": "redBright",
+    "null": "blackBright"
+  }
 }


### PR DESCRIPTION
### What does this PR do?

Plugins using `@oclif/core@v4` won't have colored JSON unless it's specified in the `theme.json` file. 

Colors were chosen based on the theme that oclif/core used to use: https://github.com/thlorenz/cardinal/blob/master/themes/jq.js

### What issues does this PR fix or reference?
[skip-validate-pr]