### PR TITLE
chore: temporarily remove oclif/core from pinnedDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,6 @@
     "strip-ansi": "^7.1.0"
   },
   "pinnedDependencies": [
-    "@oclif/core",
     "@oclif/plugin-autocomplete",
     "@oclif/plugin-commands",
     "@oclif/plugin-help",


### PR DESCRIPTION
### What does this PR do?

Temporarily remove oclif/core from pinnedDeps until PR is made to migrate to oclif/core v4

### What issues does this PR fix or reference?
[skip-validate-pr]