### PR TITLE
Allow skipping oclif promote

### DIFF
--- a/.github/workflows/promote-nightly-to-rc.yml
+++ b/.github/workflows/promote-nightly-to-rc.yml
@@ -2,9 +2,16 @@ name: promote-nightly-to-rc
 
 on:
   workflow_dispatch:
+    inputs:
+      ignore-missing:
+        type: boolean
+        required: false
+        description: Ignore 'oclif promote' errors when a specific target is missing.
   workflow_run:
     workflows:
       - promote-rc-to-latest
+      # TODO: Is there a way to see if 'ignore-missing' was passed into 'promote-rc-to-latest' and can be passed along here?
+      #       Maybe store state with upload-artifact and download-artifact?
     types:
       - completed
 
@@ -17,6 +24,7 @@ jobs:
     with:
       old-channel: nightly
       new-channel: latest-rc
+      ignore-missing: ${{ inputs.ignore-missing }}
 
   promote-verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/promote-rc-to-latest.yml
+++ b/.github/workflows/promote-rc-to-latest.yml
@@ -2,6 +2,11 @@ name: promote-rc-to-latest
 
 on:
   workflow_dispatch:
+    inputs:
+      ignore-missing:
+        type: boolean
+        required: false
+        description: Ignore 'oclif promote' errors when a specific target is missing.
   schedule:
     # Wednesdays 1pm central
     - cron: '0 18 * * 3'
@@ -14,6 +19,7 @@ jobs:
       old-channel: latest-rc
       new-channel: latest
       use-ctc: true
+      ignore-missing: ${{ inputs.ignore-missing }}
 
   promote-verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -17,6 +17,10 @@ on:
         type: boolean
         required: false
         description: Open a change case for this promotion. Only needed for promotions to latest.
+      ignore-missing:
+        type: boolean
+        required: false
+        description: Ignore 'oclif promote' errors when a specific target is missing.
   workflow_dispatch:
     inputs:
       version:
@@ -33,6 +37,10 @@ on:
         type: boolean
         required: false
         description: Open a change case for this promotion. Only needed for promotions to latest.
+      ignore-missing:
+        type: boolean
+        required: false
+        description: Ignore 'oclif promote' errors when a specific target is missing.
 
 jobs:
   validate-inputs:
@@ -180,7 +188,7 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
 
       - name: Promote with oclif
-        run: yarn promote --version "$NEEDS_GET_PACKAGE_INFO_VERSION" --sha "$NEEDS_GET_PACKAGE_INFO_SHA" --channel "$NEEDS_BUILD_S3_CHANNEL_S3_NEW_CHANNEL" --max-age 300 --macos --win --indexes --xz
+        run: yarn promote --version "$NEEDS_GET_PACKAGE_INFO_VERSION" --sha "$NEEDS_GET_PACKAGE_INFO_SHA" --channel "$NEEDS_BUILD_S3_CHANNEL_S3_NEW_CHANNEL" --max-age 300 --macos --win --indexes --xz ${{ inputs.ignore-missing && '--ignore-missing' || '' }}
         env:
           NEEDS_GET_PACKAGE_INFO_VERSION: ${{ needs.get-package-info.outputs.version }}
           NEEDS_GET_PACKAGE_INFO_SHA: ${{ needs.get-package-info.outputs.sha }}

--- a/package.json
+++ b/package.json
@@ -256,7 +256,7 @@
     "@salesforce/ts-sinon": "^1.4.27",
     "@salesforce/ts-types": "^2.0.10",
     "aws-sdk": "^2.1691.0",
-    "oclif": "^4.15.0",
+    "oclif": "^4.15.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8585,10 +8585,10 @@ obliterator@^2.0.1, obliterator@^2.0.2:
   resolved "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz"
   integrity sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ==
 
-oclif@^4.15.0:
-  version "4.15.0"
-  resolved "https://registry.yarnpkg.com/oclif/-/oclif-4.15.0.tgz#3f7df05a2060c5de92c4b0fd74a9290a60941c9e"
-  integrity sha512-o0gq69z5DrKl7KD5Ib/0csB92ewCougttbXfSoyFOvAD2GbR+RVZUptqCDry5xVM0vq49syOT5EWczJsfj5r2w==
+oclif@^4.15.1:
+  version "4.15.1"
+  resolved "https://registry.yarnpkg.com/oclif/-/oclif-4.15.1.tgz#0dfa13e9506a8d3374a180aff768df23b60a5372"
+  integrity sha512-YCElE3iM7MUDIS62UNcjH0kHWJ+VIrujgkJAFeeNQMWmpN+rdSkE0UWdKfsaHHpYKLEYrEJfHMSQm/YrekCOMQ==
   dependencies:
     "@aws-sdk/client-cloudfront" "^3.645.0"
     "@aws-sdk/client-s3" "^3.651.1"


### PR DESCRIPTION
### What does this PR do?
When adding a new arch to oclif, promotions will fail if they do not exist. This allows you to pass in the new `--ignore-missing` flag. 

Related oclif work: https://github.com/oclif/oclif/pull/1567

### What issues does this PR fix or reference?
[@W-16891787@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-16891787)