### PR TITLE
Update GHAs to use new cli:version:inspect (with sfdx removed)

### DIFF
--- a/.github/workflows/create-cli-release.yml
+++ b/.github/workflows/create-cli-release.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           max_attempts: 5
           retry_wait_seconds: 120
-          command: sf-release cli:versions:inspect -c ${{ needs.get-channel.outputs.s3-channel }} -l archive --cli sf
+          command: sf-release cli:versions:inspect -c ${{ needs.get-channel.outputs.s3-channel }} -l archive
           retry_on: error
 
   pack-upload-mac:

--- a/.github/workflows/promote-nightly-to-rc.yml
+++ b/.github/workflows/promote-nightly-to-rc.yml
@@ -23,7 +23,7 @@ jobs:
     with:
       old-channel: nightly
       new-channel: latest-rc
-      ignore-missing: ${{ inputs.ignore-missing }}
+      ignore-missing: ${{ github.event_name == 'workflow_run' && 'false' || inputs.ignore-missing }}
 
   promote-verify:
     runs-on: ubuntu-latest
@@ -55,7 +55,7 @@ jobs:
         with:
           max_attempts: 5
           retry_wait_seconds: 120
-          command: sf-release cli:versions:inspect -c stable-rc -l archive --cli sf
+          command: sf-release cli:versions:inspect -c stable-rc -l archive ${{ inputs.ignore-missing && '--ignore-missing' || '' }}
 
   verify-docker-version:
     needs: [promote-verify]

--- a/.github/workflows/promote-rc-to-latest.yml
+++ b/.github/workflows/promote-rc-to-latest.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           max_attempts: 5
           retry_wait_seconds: 120
-          command: sf-release cli:versions:inspect -c stable -l archive --cli sf
+          command: sf-release cli:versions:inspect -c stable -l archive ${{ inputs.ignore-missing && '--ignore-missing' || '' }}
 
   verify-docker-version:
     needs: [promote-verify]


### PR DESCRIPTION
### What does this PR do?
Changes to support https://github.com/salesforcecli/plugin-release-management/pull/1218

### What issues does this PR fix or reference?
[@W-16893140@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-16893140)
