### PR TITLE
fix: disable deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,11 @@
       "preparse": "/dist/hooks/preparse"
     },
     "update": {
+      "node": {
+        "options": [
+          "--no-deprecation"
+        ]
+      },
       "s3": {
         "bucket": "dfc-data-production",
         "indexVersionLimit": 140,


### PR DESCRIPTION
### What does this PR do?
follow up to https://github.com/salesforcecli/cli/pull/2025

the linked PR above just patched 2.69.14 (that week's RC), so the option added was missed in today's RC.
Re-adding it back to `main` so new nightlies pick it up.

### Acceptance Criteria
_How do you know this change is successful? What is the scope of this change? What tests test the criteria (or why no tests)?_

_The Acceptance Criteria can be copied from the work item if they exist there but it is useful to have on the PR when reviewing the code._

### Testing Notes
_Anything additional to note about testing this PR. How did you test it? Special setup? Additional manual test cases? Things not tested?_

### Checklist
- [ ] This change has been approved by the CLI Review Board or approval isn't required. Anything that adds/changes/deletes commands, flags, output, or json output has to be reviewed.
- [ ] Does this follow the [deprecation policy](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_cli_deprecation.htm)?

### What issues does this PR fix or reference?
[skip-validate-pr]