### PR TITLE
Add Python 3.10

### DIFF
--- a/dockerfiles/Dockerfile_full
+++ b/dockerfiles/Dockerfile_full
@@ -19,7 +19,7 @@ RUN mkdir /usr/local/lib/nodejs \
 ENV PATH=/usr/local/lib/nodejs/bin:$PATH
 RUN npm install --global @salesforce/cli@${SF_CLI_VERSION}
 
-RUN apt-get update && apt-get install --assume-yes openjdk-11-jdk-headless jq
+RUN apt-get update && apt-get install --assume-yes openjdk-11-jdk-headless python3.10 jq
 RUN apt-get autoremove --assume-yes \
   && apt-get clean --assume-yes \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### What does this PR do?
This Pull Request adds Python 3.10 into the Full Docker Image for compatibility with Code Analyzer v5

### Acceptance Criteria
Docker builds successfully with no errors. This change adds Python 3.10 which shows it is correctly installed as well. Can be test with the following commands in an interactive container:

1. `python --version`
2. `sf plugins install code-analyzer`
3. `sf plugins --core`

An entry for `code-analyzer 5.0.0 (5.0.0)` should be returned.

### Testing Notes
Tested using an interactive shell with Docker. Followed setup setup documented at [Set Up Code Analyzer v5 (Beta)](https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/guide/setup-cli.html).

### Checklist
- [ ] This change has been approved by the CLI Review Board or approval isn't required. Anything that adds/changes/deletes commands, flags, output, or json output has to be reviewed.
- [ ] Does this follow the [deprecation policy](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_cli_deprecation.htm)?

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/3192