### PR TITLE
chore: remove plugin-env/functions (JIT)

### DIFF
--- a/.github/workflows/just-nuts.yml
+++ b/.github/workflows/just-nuts.yml
@@ -52,8 +52,6 @@ jobs:
           - salesforcecli/plugin-dev
           - salesforcecli/plugin-signups
           # - salesforce/plugin-devops-center
-          # - salesforcecli/plugin-env
-          # - salesforce/plugin-functions
           # - salesforce/sfdx-plugin-lwc-test
           # - salesforce/sfdx-scanner
         exclude:
@@ -111,7 +109,7 @@ jobs:
       os: ${{ matrix.os }}
       command: ${{ matrix.command }}
     secrets: inherit
-  
+
   data:
     strategy:
       fail-fast: false

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,8 +17,6 @@ Plugins are npm packages written in Typescript and are hosted in the public npm 
 ### Salesforce plugins
 
 - [plugin-deploy-retrieve](https://github.com/salesforcecli/plugin-deploy-retrieve)
-- [plugin-env](https://github.com/salesforcecli/plugin-env)
-- [plugin-functions](https://github.com/salesforcecli/plugin-functions)
 - [plugin-generate](https://github.com/salesforcecli/plugin-generate)
 - [plugin-login](https://github.com/salesforcecli/plugin-login)
 - [plugin-settings](https://github.com/salesforcecli/plugin-settings)

--- a/package.json
+++ b/package.json
@@ -80,8 +80,6 @@
       "@salesforce/plugin-community": "3.3.8",
       "@salesforce/plugin-dev": "2.5.1",
       "@salesforce/plugin-devops-center": "1.2.27",
-      "@salesforce/plugin-env": "3.0.34",
-      "@salesforce/plugin-functions": "1.23.0",
       "@salesforce/plugin-signups": "2.6.10",
       "@salesforce/sfdx-plugin-lwc-test": "1.2.1",
       "@salesforce/sfdx-scanner": "4.8.0"


### PR DESCRIPTION
### What does this PR do?
Removes `plugin-env` and `plugin-functions` from the JIT plugins list

### What issues does this PR fix or reference?
@W-17668437@
