### PR TITLE
W-18218507 increase retry timeout

### DIFF
--- a/.github/workflows/just-nut.yml
+++ b/.github/workflows/just-nut.yml
@@ -99,5 +99,5 @@ jobs:
       - name: Run NUT (with retries)
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
-          timeout_minutes: 30
+          retry_wait_seconds: 1800
           command: ${{ inputs.command }}

--- a/.github/workflows/just-nut.yml
+++ b/.github/workflows/just-nut.yml
@@ -99,5 +99,5 @@ jobs:
       - name: Run NUT (with retries)
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
-          retry_wait_seconds: 1
+          timeout_minutes: 30
           command: ${{ inputs.command }}


### PR DESCRIPTION
Increases the retry timeout in an attempt to see this error less often when running NUTs:
`ConcurrentRequests (Concurrent API Requests) Limit exceeded`

[@W-18218507@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-18218507)