### PR TITLE
W-18398261: disable plugin-agent NUTs for now

### DIFF
--- a/.github/workflows/just-nuts.yml
+++ b/.github/workflows/just-nuts.yml
@@ -51,7 +51,7 @@ jobs:
           - salesforcecli/plugin-community
           - salesforcecli/plugin-dev
           - salesforcecli/plugin-signups
-          - salesforcecli/plugin-agent
+          # - salesforcecli/plugin-agent
           # - salesforce/plugin-devops-center
           # - salesforce/sfdx-plugin-lwc-test
           # - salesforce/sfdx-scanner


### PR DESCRIPTION
### What does this PR do?
plugin-agent needs a specific sandbox for the NUTs to work. Disabling this for now until we complete [@W-18398261@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-18398261)