### PR TITLE
W-18838682 Enable plugin-agent nuts

### DIFF
--- a/.github/workflows/just-nuts.yml
+++ b/.github/workflows/just-nuts.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         repository:
-          # - salesforcecli/plugin-agent
+          - salesforcecli/plugin-agent
           - salesforcecli/plugin-auth
           - salesforcecli/plugin-apex
           - salesforcecli/plugin-api


### PR DESCRIPTION
### What does this PR do?
Enables `plugin-agent` NUTs

These should pass now that this is merged https://github.com/salesforcecli/plugin-agent/pull/166

### What issues does this PR fix or reference?
[@W-18838682@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-18838682)