### PR TITLE
chore(ci): fix numerical comparison

### DIFF
--- a/.github/workflows/make-pr-for-nightly.yml
+++ b/.github/workflows/make-pr-for-nightly.yml
@@ -95,9 +95,9 @@ jobs:
       - name: Build nightly PR (minor)
         run: sf-release cli:release:build --start-from-github-ref main ${{ inputs.only && format('--only {0}', inputs.only) || '' }} --label nightly-automerge --release-channel nightly
         # If the package.json 'minor' IS EQUAL TO the latest-rc 'minor', we want to bump 'minor'
-        if: ${{ steps.package-json-semver-info.outputs.minor == steps.latest-rc-semver-info.outputs.minor }}
+        if: ${{ fromJSON(steps.package-json-semver-info.outputs.minor) == fromJSON(steps.latest-rc-semver-info.outputs.minor) }}
 
       - name: Build nightly PR (patch)
         run: sf-release cli:release:build --start-from-github-ref main --patch ${{ inputs.only && format('--only {0}', inputs.only) || '' }} --label nightly-automerge --release-channel nightly
         # If the package.json 'minor' IS GREATER THAN the latest-rc 'minor', we want to bump 'patch'
-        if: ${{ steps.package-json-semver-info.outputs.minor > steps.latest-rc-semver-info.outputs.minor }}
+        if: ${{ fromJSON(steps.package-json-semver-info.outputs.minor) > fromJSON(steps.latest-rc-semver-info.outputs.minor) }}


### PR DESCRIPTION
### What does this PR do?
Fix the string comparison done in the nightly PR workflow that was blocking new nightly releases after the `2.100.0` RC, see copilot explanation below ⏬ 

### Acceptance Criteria
_How do you know this change is successful? What is the scope of this change? What tests test the criteria (or why no tests)?_

_The Acceptance Criteria can be copied from the work item if they exist there but it is useful to have on the PR when reviewing the code._

### Testing Notes

Successfully created a 2.100.1 nightly from this branch:
https://github.com/salesforcecli/cli/actions/runs/16606422530/job/46979279048

docs:
https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#operators

🪄 fixed by copilot agent using sonnet 4, prompt:
```
// open file: cli/.github/workflows/make-pr-for-nightly.yml

this workflows isn't triggering none of the "Build night PR" steps, the "Log  version info" outputs this:

\`\`\`
Run echo "[INFO] Semver version in 'latest-rc' is: $STEPS_LATEST_RC_VERSION_VERSION"
[INFO] Semver version in 'latest-rc' is: 2.99.6
[INFO] Semver minor in 'latest-rc' is: 99
[INFO] Semver version in 'main' is: 2.100.0
[INFO] Semver minor in 'main' is: 100
\`\`\`
```

⬇️ 

```
The issue is that GitHub Actions is likely treating the step outputs as strings, not numbers, when doing the comparison. When comparing strings, '100' > '99' is actually false because string comparison is lexicographic (character by character), and '1' comes before '9' in ASCII.

The fix I applied wraps the step outputs with fromJSON() to convert the string values to numbers before comparison. This ensures that:

fromJSON('100') > fromJSON('99') evaluates to true (numeric comparison)
Instead of '100' > '99' which evaluates to false (string comparison)
With your current values:

latest-rc minor: 99
main (package.json) minor: 100
Now the condition fromJSON(100) > fromJSON(99) will correctly evaluate to true, and the "Build nightly PR (patch)" step should execute.The fix I applied wraps the step outputs with fromJSON() to convert the string values to numbers before comparison. This ensures that:

fromJSON('100') > fromJSON('99') evaluates to true (numeric comparison)
Instead of '100' > '99' which evaluates to false (string comparison)
With your current values:

latest-rc minor: 99
main (package.json) minor: 100
Now the condition fromJSON(100) > fromJSON(99) will correctly evaluate to true, and the "Build nightly PR (patch)" step should execute.
```



### What issues does this PR fix or reference?
[skip-validate-pr]
