### PR TITLE
W-19190281: remove sfdx-scanner from JIT list

### DIFF
--- a/.github/workflows/just-nuts.yml
+++ b/.github/workflows/just-nuts.yml
@@ -54,7 +54,6 @@ jobs:
           - salesforcecli/plugin-signups
           # - salesforce/plugin-devops-center
           # - salesforce/sfdx-plugin-lwc-test
-          # - salesforce/sfdx-scanner
         exclude:
           - os: windows-latest
             repository: salesforcecli/plugin-dev # These are flakey on Windows

--- a/package.json
+++ b/package.json
@@ -83,8 +83,7 @@
       "@salesforce/plugin-devops-center": "1.2.27",
       "@salesforce/plugin-flow": "1.0.2",
       "@salesforce/plugin-signups": "2.6.39",
-      "@salesforce/sfdx-plugin-lwc-test": "1.2.1",
-      "@salesforce/sfdx-scanner": "4.12.0"
+      "@salesforce/sfdx-plugin-lwc-test": "1.2.1"
     },
     "devPlugins": [
       "@oclif/plugin-command-snapshot",


### PR DESCRIPTION
### What does this PR do?
`sfdx-scanner` is [deprecated](https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/guide/release-notes.html#code-analyzer-v4120-end-of-life). This PR removes the deprecated plugin from the Just In Time (JIT) list. 

### What issues does this PR fix or reference?
[@W-19190281@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-19190281)
https://salesforce-internal.slack.com/archives/G0213NY8PMH/p1754069175598669
