### PR TITLE
chore: change nsis script to use global cmd.exe @W-19315214@

### DIFF
--- a/scripts/nsis.nsi
+++ b/scripts/nsis.nsi
@@ -48,18 +48,16 @@ FunctionEnd
 
 Function .onInit
 
-  ; Securely locate global cmd.exe (System32 or Sysnative)
-  StrCpy $R9 "$WINDIR\System32\cmd.exe"
-  IfFileExists "$R9" 0 check_sysnative
-    Goto cmd_found
-  check_sysnative:
-  StrCpy $R9 "$WINDIR\Sysnative\cmd.exe"
-  IfFileExists "$R9" 0 cmd_not_found
-    Goto cmd_found
-  cmd_not_found:
-  MessageBox MB_OK|MB_ICONSTOP "Error: Could not find global cmd.exe. Installation cannot continue."
-  Quit
-  cmd_found:
+  ; Use explicit System32/Sysnative path to cmd.exe for security
+  ; $R9 becomes the path to the global cmd.exe
+  StrCpy $R9 "$WINDIR\\System32\\cmd.exe"  ; Try System32 first
+  IfFileExists "$R9" path_is_safe
+    StrCpy $R9 "$WINDIR\\Sysnative\\cmd.exe"  ; Try Sysnative for WOW64
+    IfFileExists "$R9" path_is_safe
+      MessageBox MB_OK|MB_ICONSTOP "Error: Could not find system cmd.exe. Installation cannot continue."
+      Abort
+      
+  path_is_safe:
 
   nsExec::ExecToStack /TIMEOUT=2000 '"$R9" /c "sfdx --version"'
   ; exit code is stored on $0 first, then stdout


### PR DESCRIPTION
### What does this PR do?
changes the custom nsis used in `sf` for checking for installed `sfdx` CLI to use the global cmd.exe instead of a local, possibly malicious cmd.exe file

### Acceptance Criteria


### Testing Notes
oh boi - needs a windows machine
needs https://github.com/oclif/oclif/pull/1852

setup:
(I had to delete the JIT section in pjson in CLI for some steps to work locally)
1. be on windows
2. checkout the oclif PR / yarn / yarn build
3. checkout this PR / yarn / 
4. run `oclif pack:tarballs --xz --parallel --prune-lockfiles --targets win32-x64` or whatever windows target you need (just builds one, instead of every, installer)
5. `../path/to/oclif/bin/run.js pack:win --prune-lockfiles --targets win32-x64  --defender-exclusion unchecked`
6. If step 6 fails, there's a good chance it was at least able to build the `.nsi` file. I believe this file is in the output, and it's in `tmp/`. You can `makensis path/to/.nsi` which will compile your `.nsi` into a `.exe`, you can then drag that .exe into your testing folder
7. drag the new built installer from `dist/` to your directory with a "malicious" cmd.exe program in it and install

Notes:
sometimes the `pack:win` command would fail, but I'd still get the required `sf.nsi` file, which then I'd have to run `makensis path/to/sf.nsi` which would build the installer

### Checklist
- [x] This change has been approved by the CLI Review Board or approval isn't required. Anything that adds/changes/deletes commands, flags, output, or json output has to be reviewed.
- [x] Does this follow the [deprecation policy](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_cli_deprecation.htm)?

### What issues does this PR fix or reference?
@W-19315214@