### PR TITLE
@W-23253606: pass node version override to ctcOpen/ctcClose in promote

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -115,6 +115,7 @@ jobs:
           SF_CHANGE_CASE_CONFIGURATION_ITEM: ${{ secrets.SF_CHANGE_CASE_CONFIGURATION_ITEM }}
           SVC_CLI_BOT_GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
           githubTag: ${{ inputs.version }}
+          nodeVersion: ${{ vars.NODE_VERSION_OVERRIDE || 'lts/*' }}
 
       - name: Check open-ctc status
         if: always()
@@ -205,6 +206,7 @@ jobs:
     secrets: inherit
     with:
       changeCaseId: ${{ needs.open-ctc-or-skip.outputs.changeCaseId }}
+      nodeVersion: ${{ vars.NODE_VERSION_OVERRIDE || 'lts/*' }}
 
   ctcCloseFail:
     needs: [open-ctc-or-skip, npm-promote, docker-promote, oclif-promote]
@@ -213,4 +215,5 @@ jobs:
     secrets: inherit
     with:
       changeCaseId: ${{ needs.open-ctc-or-skip.outputs.changeCaseId }}
+      nodeVersion: ${{ vars.NODE_VERSION_OVERRIDE || 'lts/*' }}
       status: Not Implemented


### PR DESCRIPTION
### What does this PR do?
Passes `NODE_VERSION_OVERRIDE` to the ctcOpen action and ctcClose workflow calls in the promote workflow. The npm-promote and oclif-promote jobs already use the override, but ctcOpen and ctcClose were still using the default `lts/*`.

### What issues does this PR fix or reference?
[@W-23253606@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-23253606)