### PR TITLE
fix: drop Node 18/20 support, require >=22 @W-23388103@

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/forcedotcom/cli",
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "engines": {
-    "node": ">=18.6.0"
+    "node": ">=22.0.0"
   },
   "packageManager": "yarn@1.22.19",
   "files": [
@@ -233,7 +233,7 @@
     "pack:tarballs": "oclif pack:tarballs --xz --parallel --prune-lockfiles",
     "pack:tarballs:sequential": "oclif pack:tarballs --xz --prune-lockfiles",
     "pack:verify": "sf-release cli:tarballs:verify --cli sf --windows-username-buffer 34",
-    "pack:win": "oclif pack:win --prune-lockfiles --defender-exclusion unchecked",
+    "pack:win": "oclif pack:win --targets win32-x64,win32-arm64 --prune-lockfiles --defender-exclusion unchecked",
     "postpack": "rm -f oclif.manifest.json npm-shrinkwrap.json",
     "preinstall": "node ./scripts/preinstall.js",
     "prepack": "sf-prepack",


### PR DESCRIPTION
## Summary
- Bump `engines.node` from `>=18.0.0` to `>=22.0.0`
- Node 18 reached EOL September 2025, Node 20 reached EOL April 2026
- Fresh installs already crash on Node 18/20 due to `@jsforce/jsforce-node@3.10.17` pulling `undici@^8.5.0` (requires Node >=22)
- **Drop `win32-x86` (32-bit Windows) build** by passing `--targets win32-x64,win32-arm64` to `pack:win`. The standalone builds move to Node 24, which no longer ships 32-bit Windows binaries. Telemetry shows 32-bit Windows is ~0.01% of CLI usage (~350 machines), and ~84% of those were already on EOL Node and non-functional on current releases.

Fixes https://github.com/forcedotcom/cli/issues/3596
Related https://github.com/forcedotcom/cli/issues/3603

## Work Item
@W-23388103@: [CLI] Use node v24, deprecate 18 and 20

## Merge / sequencing note
The `win32-x86` removal pairs with bundling Node 24 (deleting the `NODE_VERSION_OVERRIDE` repo variable, or setting it to `24.x`). Node 24 has no `win-x86` binary. Note: oclif already auto-skips `win32-x86` when the bundled Node is `>24.0.0`, so the explicit `--targets` flag makes the intent clear and also drops x86 while still pinned to Node 22. After merge + var deletion, trigger a nightly and confirm only x64/arm64 Windows tarballs upload.

## Test plan
- [ ] CI passes on Node 22 and 24 (already the case — CI has not tested 18/20 since they went EOL)
- [ ] npm install on Node <22 shows engines warning
- [ ] Post-merge: nightly builds only win32-x64 and win32-arm64, no x86 pack failure