### PR TITLE
fix: pass yarn cache inputs to ctcClose in promote workflow

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -209,6 +209,8 @@ jobs:
     with:
       changeCaseId: ${{ needs.open-ctc-or-skip.outputs.changeCaseId }}
       nodeVersion: ${{ vars.NODE_VERSION_OVERRIDE || 'lts/*' }}
+      package-manager: yarn
+      cache-dependency-path: yarn.lock
 
   ctcCloseFail:
     needs: [open-ctc-or-skip, npm-promote, docker-promote, oclif-promote]
@@ -218,4 +220,6 @@ jobs:
     with:
       changeCaseId: ${{ needs.open-ctc-or-skip.outputs.changeCaseId }}
       nodeVersion: ${{ vars.NODE_VERSION_OVERRIDE || 'lts/*' }}
+      package-manager: yarn
+      cache-dependency-path: yarn.lock
       status: Not Implemented


### PR DESCRIPTION
## Summary

- Pass `package-manager: yarn` and `cache-dependency-path: yarn.lock` to both `ctcCloseSuccess` and `ctcCloseFail` jobs
- Same root cause as #2882 — the shared `ctcClose.yml` workflow defaults to npm/package-lock.json caching which doesn't exist in this repo

## Context

The promotions themselves complete fine (npm, docker, oclif/S3), but the CTC close step fails afterward because of the same missing lockfile issue. The promote workflow still shows as failed even though the actual promotion succeeded.

## Test plan

- [ ] Re-run promote workflow and confirm `ctcCloseSuccess` passes