### PR TITLE
docs: point plugin developer guide link to Salesforce docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 # Getting Started
 
 - [Release notes](https://github.com/forcedotcom/cli/tree/main/releasenotes)
-- Read the [sf Plugin Developer Guide](https://github.com/salesforcecli/cli/wiki/Quick-Introduction-to-Developing-sf-Plugins) to learn how to develop a `sf` plugin.
-- Are you migrating an `sfdx` plugin to `sf`? Then check out the [migration section](https://github.com/salesforcecli/cli/wiki/Migrate-Plugins-Built-for-sfdx) of the developer guide.
+- Read the [Overview of Salesforce CLI Plugins](https://developer.salesforce.com/docs/platform/salesforce-cli-plugin/guide/conceptual-overview.html) to learn how to develop a `sf` plugin.
+- Are you migrating an `sfdx` plugin to `sf`? Then check out the [Migrate Plugins Built for sfdx to sf](https://developer.salesforce.com/docs/platform/salesforce-cli-plugin/guide/migrate-sfdx-sf.html) of the developer guide.
 - Read [this section of the Setup Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_move_to_sf_v2.htm) for easy instructions on how to move from your `sfdx` (v7) installation to `sf` (v2).
 
 # Feedback


### PR DESCRIPTION
## Summary
- Updates the "Getting Started" link in the README from the old GitHub wiki page to the official Salesforce CLI Plugin Developer Guide.

## Why
The wiki page is outdated; the official docs at developer.salesforce.com are the current, maintained source for this guide.

## Test plan
- [x] Verified the new link resolves correctly: https://developer.salesforce.com/docs/platform/salesforce-cli-plugin/guide/conceptual-overview.html

---
A sincere thank you to the maintainers and everyone who contributes to this CLI — it's a fantastic tool that many of us rely on daily. I really appreciate the time and care that goes into maintaining it. Happy to contribute this small doc fix, and looking forward to helping out again in the future!
